### PR TITLE
feat: Add color picker example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:example/pages/8_color_picker_example_page.dart';
 import 'package:flutter/material.dart';
 
 // Importa la página de vista previa
@@ -90,6 +91,11 @@ class ExampleHomePage extends StatelessWidget {
         'title': '7. Aspect Ratio',
         'subtitle': 'Creating a 9:16 story.',
         'page': const AspectRatioExamplePage(),
+      },
+      {
+        'title': '8. Color Picker',
+        'subtitle': 'Integrating a full color picker dialog.',
+        'page': const ColorPickerExamplePage(),
       },
     ];
 

--- a/example/lib/pages/8_color_picker_example_page.dart
+++ b/example/lib/pages/8_color_picker_example_page.dart
@@ -1,0 +1,82 @@
+import 'package:escribo/escribo.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart'; // Importa el paquete
+import '../main.dart';
+
+class ColorPickerExamplePage extends StatefulWidget {
+  const ColorPickerExamplePage({super.key});
+
+  @override
+  State<ColorPickerExamplePage> createState() => _ColorPickerExamplePageState();
+}
+
+class _ColorPickerExamplePageState extends State<ColorPickerExamplePage> {
+  // Guardamos una paleta de colores en el estado de la página.
+  // Esto nos permite modificarla y forzar la reconstrucción de EscriboEditor.
+  late List<Color> _palette;
+
+  @override
+  void initState() {
+    super.initState();
+    // Inicializamos la paleta con un color por defecto.
+    _palette = [Colors.deepPurple];
+  }
+
+  // Esta función abrirá el diálogo del selector de color.
+  void _pickColor(BuildContext context) {
+    Color pickerColor = _palette.first; // El color actual
+
+    showDialog(
+      context: context,
+      builder:
+          (context) => AlertDialog(
+            title: const Text('Pick a color'),
+            content: SingleChildScrollView(
+              child: ColorPicker(
+                pickerColor: pickerColor,
+                onColorChanged: (color) => pickerColor = color,
+              ),
+            ),
+            actions: <Widget>[
+              ElevatedButton(
+                child: const Text('Done'),
+                onPressed: () {
+                  setState(() {
+                    // Al presionar "Done", actualizamos nuestra paleta.
+                    // Reemplazamos el primer color con el nuevo color seleccionado.
+                    // Esto hará que EscriboEditor se reconstruya con el nuevo color disponible.
+                    _palette[0] = pickerColor;
+                  });
+                  Navigator.of(context).pop();
+                },
+              ),
+            ],
+          ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return EscriboEditor(
+      onSave: (imageBytes) {
+        showImageSavedDialog(context, imageBytes);
+      },
+      // Pasamos nuestra paleta de estado al editor.
+      // Cuando la paleta cambie, el editor se actualizará.
+      colorPalette: _palette,
+
+      // Aquí está la magia: reemplazamos el botón de color por defecto.
+      colorButtonBuilder: (buttonContext, toggleVisibility) {
+        // Ignoramos el callback `toggleVisibility` porque tenemos nuestro propio sistema.
+        return IconButton(
+          icon: const Icon(Icons.colorize, color: Colors.white, size: 30),
+          tooltip: 'Open Color Picker',
+          onPressed: () {
+            // Al presionar, llamamos a nuestra función que abre el diálogo.
+            _pickColor(buttonContext);
+          },
+        );
+      },
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -85,6 +85,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_colorpicker:
+    dependency: "direct main"
+    description:
+      name: flutter_colorpicker
+      sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,10 +35,13 @@ dependencies:
   # Añade esta sección para vincular tu paquete 'escribo'
   escribo:
     path: ../
+
+
     
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_colorpicker: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Creates a new example page (ColorPickerExamplePage). Demonstrates how to use colorButtonBuilder to override default UI. Integrates the flutter_colorpicker package to show a full-featured color picker dialog. Updates example/pubspec.yaml with the new dependency.