### PR TITLE
feat: Add embedded editor example page

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,24 +1,25 @@
 import 'dart:typed_data';
 import 'package:example/pages/8_color_picker_example_page.dart';
+import 'package:example/pages/9_embedded_editor_example_page.dart';
 import 'package:flutter/material.dart';
 
-// Importa la página de vista previa
+// Import preview page
 import 'preview_page.dart';
 
-// Importa todas las páginas de ejemplo
+// Import all example pages
 import 'pages/1_basic_example_page.dart';
 import 'pages/2_themed_example_page.dart';
 import 'pages/3_minimalist_layout_page.dart';
 import 'pages/4_advanced_layout_page.dart';
 import 'pages/5_validation_example_page.dart';
 import 'pages/6_branded_editor_page.dart';
-import 'pages/7_aspect_ratio_example_page.dart'; // Asegúrate de que esta importación esté presente
+import 'pages/7_aspect_ratio_example_page.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-// Navega a una página de vista previa a pantalla completa.
+// Navigate to a full-screen preview page
 void showImageSavedDialog(BuildContext context, Uint8List imageBytes) {
   Navigator.push(
     context,
@@ -55,7 +56,7 @@ class ExampleHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // CORRECCIÓN: La lista de ejemplos ahora incluye las 7 páginas.
+    // List of examples now includes all 9 pages
     final examples = [
       {
         'title': '1. Basic Example',
@@ -96,6 +97,11 @@ class ExampleHomePage extends StatelessWidget {
         'title': '8. Color Picker',
         'subtitle': 'Integrating a full color picker dialog.',
         'page': const ColorPickerExamplePage(),
+      },
+      {
+        'title': '9. Embedded Editor',
+        'subtitle': 'Displaying the editor inside a container.',
+        'page': const EmbeddedEditorExamplePage(),
       },
     ];
 

--- a/example/lib/pages/1_basic_example_page.dart
+++ b/example/lib/pages/1_basic_example_page.dart
@@ -1,6 +1,6 @@
 import 'package:escribo/escribo.dart';
 import 'package:flutter/material.dart';
-import '../main.dart'; // To use the helper dialog
+import '../main.dart';
 
 class BasicExamplePage extends StatelessWidget {
   const BasicExamplePage({super.key});

--- a/example/lib/pages/2_themed_example_page.dart
+++ b/example/lib/pages/2_themed_example_page.dart
@@ -8,7 +8,7 @@ class ThemedExamplePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // A custom "Vaporwave" theme for our editor
+    // Custom "Vaporwave" theme
     final vaporwaveFonts = [
       GoogleFonts.pressStart2p(fontSize: 32, color: Colors.cyanAccent),
       GoogleFonts.majorMonoDisplay(

--- a/example/lib/pages/3_minimalist_layout_page.dart
+++ b/example/lib/pages/3_minimalist_layout_page.dart
@@ -11,7 +11,7 @@ class MinimalistLayoutPage extends StatelessWidget {
       onSave: (imageBytes) {
         showImageSavedDialog(context, imageBytes);
       },
-      // This builder completely changes the text input experience.
+      // Custom text input experience
       textEditorBuilder: (context, controller, style) {
         return Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/example/lib/pages/4_advanced_layout_page.dart
+++ b/example/lib/pages/4_advanced_layout_page.dart
@@ -30,7 +30,6 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children:
               _getColors(context).map((color) {
-                // <- Inicio del .map()
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: InkWell(
@@ -52,7 +51,7 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
                     ),
                   ),
                 );
-              }).toList(), // <- CORRECCIÓN: .toList() añadido aquí
+              }).toList(),
         );
       },
 
@@ -61,7 +60,6 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children:
               fontStyles.map((style) {
-                // <- Inicio del .map()
                 final isSelected = currentStyle == style;
                 return TextButton(
                   onPressed: () => onFontSelected(style),
@@ -77,7 +75,7 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
                     ),
                   ),
                 );
-              }).toList(), // <- CORRECCIÓN: .toList() añadido aquí
+              }).toList(),
         );
       },
 
@@ -139,7 +137,6 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children:
                         _aspectRatios.keys.map((label) {
-                          // <- Inicio del .map()
                           final value = _aspectRatios[label]!;
                           return ChoiceChip(
                             label: Text(label),
@@ -150,7 +147,7 @@ class _AdvancedLayoutPageState extends State<AdvancedLayoutPage> {
                                 setState(() => _currentAspectRatio = value);
                             },
                           );
-                        }).toList(), // <- CORRECCIÓN: .toList() añadido aquí
+                        }).toList(),
                   ),
                 ),
               ],

--- a/example/lib/pages/5_validation_example_page.dart
+++ b/example/lib/pages/5_validation_example_page.dart
@@ -13,11 +13,11 @@ class ValidationExamplePage extends StatelessWidget {
       },
       // Enable validation
       validateOnSave: true,
-      // Provide a custom rule: the text must contain "Escribo"
+      // Custom validation rule: text must contain "Escribo"
       textValidator: (text) {
         return text.toLowerCase().contains('escribo');
       },
-      // Provide feedback when validation fails
+      // Show feedback when validation fails
       onValidationFail: () {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(

--- a/example/lib/pages/6_branded_editor_page.dart
+++ b/example/lib/pages/6_branded_editor_page.dart
@@ -11,15 +11,12 @@ class BrandedEditorPage extends StatelessWidget {
       onSave: (imageBytes) {
         showImageSavedDialog(context, imageBytes);
       },
-      // MODIFICACIÓN: Para añadir una marca de agua que SÍ sea parte de la
-      // imagen final, debemos usar un builder que renderice DENTRO de la
-      // zona de captura. `textEditorBuilder` es el lugar perfecto para esto.
+      // Add watermark that will be captured in the final image
       textEditorBuilder: (context, controller, style) {
-        // Usamos un Stack para colocar la marca de agua encima del campo de texto.
+        // Stack to place watermark above text field
         return Stack(
           children: [
-            // Primero, replicamos el comportamiento del editor de texto por defecto
-            // para que el usuario pueda seguir escribiendo normalmente.
+            // Default text editor behavior
             Center(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 24.0),
@@ -37,14 +34,13 @@ class BrandedEditorPage extends StatelessWidget {
                 ),
               ),
             ),
-            // Después, añadimos nuestra marca de agua encima, que ahora
-            // SÍ será capturada por el Screenshot.
+            // Watermark that will be captured by Screenshot
             Positioned(
-              bottom: 20, // Posiciónalo dentro del canvas
+              bottom: 20, // Position within canvas
               right: 20,
               child: Row(
                 children: [
-                  const FlutterLogo(size: 20), // Un poco más pequeño
+                  const FlutterLogo(size: 20), // Smaller size
                   const SizedBox(width: 8),
                   Text(
                     'Powered by Escribo',

--- a/example/lib/pages/7_aspect_ratio_example_page.dart
+++ b/example/lib/pages/7_aspect_ratio_example_page.dart
@@ -1,19 +1,18 @@
 import 'package:escribo/escribo.dart';
 import 'package:flutter/material.dart';
-import '../main.dart'; // Para usar la función de vista previa de imagen
+import '../main.dart';
 
 class AspectRatioExamplePage extends StatelessWidget {
   const AspectRatioExamplePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Este ejemplo muestra cómo usar la propiedad `aspectRatio` para crear
-    // un canvas con una proporción específica, como la de una historia de Instagram.
+    // Example showing how to use aspectRatio for Instagram story format
     return EscriboEditor(
-      // Establecemos el aspect ratio a 9:16 para un formato vertical de historia.
+      // Set aspect ratio to 9:16 for vertical story format
       aspectRatio: 9 / 16,
       onSave: (imageBytes) {
-        // Al guardar, navegamos a la página de vista previa.
+        // Navigate to preview page when saving
         showImageSavedDialog(context, imageBytes);
       },
     );

--- a/example/lib/pages/8_color_picker_example_page.dart
+++ b/example/lib/pages/8_color_picker_example_page.dart
@@ -1,6 +1,6 @@
 import 'package:escribo/escribo.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_colorpicker/flutter_colorpicker.dart'; // Importa el paquete
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import '../main.dart';
 
 class ColorPickerExamplePage extends StatefulWidget {
@@ -11,20 +11,19 @@ class ColorPickerExamplePage extends StatefulWidget {
 }
 
 class _ColorPickerExamplePageState extends State<ColorPickerExamplePage> {
-  // Guardamos una paleta de colores en el estado de la página.
-  // Esto nos permite modificarla y forzar la reconstrucción de EscriboEditor.
+  // Store color palette in page state to trigger EscriboEditor rebuild
   late List<Color> _palette;
 
   @override
   void initState() {
     super.initState();
-    // Inicializamos la paleta con un color por defecto.
+    // Initialize palette with default color
     _palette = [Colors.deepPurple];
   }
 
-  // Esta función abrirá el diálogo del selector de color.
+  // Open color picker dialog
   void _pickColor(BuildContext context) {
-    Color pickerColor = _palette.first; // El color actual
+    Color pickerColor = _palette.first; // Current color
 
     showDialog(
       context: context,
@@ -42,9 +41,7 @@ class _ColorPickerExamplePageState extends State<ColorPickerExamplePage> {
                 child: const Text('Done'),
                 onPressed: () {
                   setState(() {
-                    // Al presionar "Done", actualizamos nuestra paleta.
-                    // Reemplazamos el primer color con el nuevo color seleccionado.
-                    // Esto hará que EscriboEditor se reconstruya con el nuevo color disponible.
+                    // Update palette with new selected color
                     _palette[0] = pickerColor;
                   });
                   Navigator.of(context).pop();
@@ -61,18 +58,17 @@ class _ColorPickerExamplePageState extends State<ColorPickerExamplePage> {
       onSave: (imageBytes) {
         showImageSavedDialog(context, imageBytes);
       },
-      // Pasamos nuestra paleta de estado al editor.
-      // Cuando la paleta cambie, el editor se actualizará.
+      // Pass state palette to editor - will update when palette changes
       colorPalette: _palette,
 
-      // Aquí está la magia: reemplazamos el botón de color por defecto.
+      // Replace default color button with custom picker
       colorButtonBuilder: (buttonContext, toggleVisibility) {
-        // Ignoramos el callback `toggleVisibility` porque tenemos nuestro propio sistema.
+        // Ignore default toggleVisibility callback
         return IconButton(
           icon: const Icon(Icons.colorize, color: Colors.white, size: 30),
           tooltip: 'Open Color Picker',
           onPressed: () {
-            // Al presionar, llamamos a nuestra función que abre el diálogo.
+            // Open color picker dialog
             _pickColor(buttonContext);
           },
         );

--- a/example/lib/pages/9_embedded_editor_example_page.dart
+++ b/example/lib/pages/9_embedded_editor_example_page.dart
@@ -1,0 +1,144 @@
+import 'package:escribo/escribo.dart';
+import 'package:flutter/material.dart';
+
+class EmbeddedEditorExamplePage extends StatefulWidget {
+  const EmbeddedEditorExamplePage({super.key});
+
+  @override
+  State<EmbeddedEditorExamplePage> createState() =>
+      _EmbeddedEditorExamplePageState();
+}
+
+class _EmbeddedEditorExamplePageState extends State<EmbeddedEditorExamplePage> {
+  // Boolean to control editor visibility
+  bool _isEditorVisible = false;
+
+  // Widget to show when editor is hidden
+  Widget _buildPlaceholder() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.add_photo_alternate_outlined,
+            size: 80,
+            color: Colors.grey.shade400,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Create a visual status',
+            style: TextStyle(fontSize: 18, color: Colors.grey.shade500),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Widget to build the editor
+  Widget _buildEditor() {
+    return EscriboEditor(
+      onSave: (imageBytes) {
+        // Hide editor and show feedback when saving
+        setState(() => _isEditorVisible = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            backgroundColor: Colors.teal,
+            content: Text('Status saved successfully! (Simulated)'),
+          ),
+        );
+      },
+      // Override close button to control this page's state
+      closeButtonBuilder: (context, onClose) {
+        // Ignore default onClose and use our own setState
+        return IconButton(
+          icon: const Icon(Icons.close, color: Colors.white),
+          onPressed: () => setState(() => _isEditorVisible = false),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Embedded Editor')),
+      // Gradient background for styling
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFFE0F2F1), Color(0xFFB2DFDB)],
+          ),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Container with specific size to house the editor
+                Container(
+                  height: 500, // Fixed height
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(16),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.1),
+                        blurRadius: 10,
+                        offset: const Offset(0, 4),
+                      ),
+                    ],
+                  ),
+                  // ClipRRect ensures editor respects rounded corners
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(16),
+                    // AnimatedSwitcher for smooth transition
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 400),
+                      transitionBuilder: (child, animation) {
+                        return FadeTransition(opacity: animation, child: child);
+                      },
+                      // Show placeholder or editor based on state
+                      child:
+                          _isEditorVisible
+                              ? _buildEditor()
+                              : _buildPlaceholder(),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                // Button that controls visibility
+                ElevatedButton.icon(
+                  icon: Icon(
+                    _isEditorVisible ? Icons.visibility_off : Icons.add,
+                  ),
+                  label: Text(
+                    _isEditorVisible ? 'Hide Editor' : 'Create Status',
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor:
+                        _isEditorVisible ? Colors.grey : Colors.teal,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    textStyle: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _isEditorVisible = !_isEditorVisible;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/preview_page.dart
+++ b/example/lib/preview_page.dart
@@ -11,23 +11,21 @@ class PreviewPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Saved Image Preview'),
-        // Usamos un botón de cerrar para que la acción sea más clara
+        // Use close button to make action clearer
         leading: IconButton(
           icon: const Icon(Icons.close),
           onPressed: () {
-            // Hacemos pop dos veces para cerrar la vista previa Y el editor,
-            // volviendo así a la lista de ejemplos.
-            Navigator.of(context).pop();
+            // returning to preview
             Navigator.of(context).pop();
           },
         ),
       ),
-      // Un fondo oscuro para que la imagen resalte
+      // Dark background to make image stand out
       backgroundColor: Colors.black87,
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          // El widget Image.memory es perfecto para mostrar bytes de imagen
+          // Image.memory widget is perfect for displaying image bytes
           child: Image.memory(imageBytes),
         ),
       ),

--- a/lib/src/escribo_editor.dart
+++ b/lib/src/escribo_editor.dart
@@ -4,7 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:screenshot/screenshot.dart';
 
 class EscriboEditor extends StatefulWidget {
-  // ... (todas las propiedades no cambian)
+  // All properties remain unchanged
   final Function(Uint8List imageBytes) onSave;
   final List<TextStyle> fontStyles;
   final List<Color> colorPalette;
@@ -67,7 +67,7 @@ class EscriboEditor extends StatefulWidget {
 }
 
 class _EscriboEditorState extends State<EscriboEditor> {
-  // ... (el estado no cambia)
+  // State remains unchanged
   late final TextEditingController _textController;
   late List<TextStyle> _fontStyles;
   late List<Color> _colorPalette;
@@ -77,7 +77,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
   bool _isFontSelectorVisible = false;
   final ScreenshotController _screenshotController = ScreenshotController();
 
-  // ... (initState, dispose, y otros métodos no cambian)
+  // initState, dispose, and other methods remain unchanged
   @override
   void initState() {
     super.initState();
@@ -171,7 +171,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
             ?.call(context, _textController, currentStyle) ??
         _buildDefaultTextEditor(currentStyle);
 
-    // MODIFICACIÓN CRÍTICA: Construimos el canvas aquí para que esté disponible para todos los builders.
+    // CRITICAL MODIFICATION: Build canvas here so it's available for all builders
     final canvas = Screenshot(
       controller: _screenshotController,
       child: AspectRatio(
@@ -187,7 +187,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
           _buildDefaultFontButton(isActive: _isFontSelectorVisible),
       widget.colorButtonBuilder?.call(context, _toggleColorPaletteVisibility) ??
           _buildDefaultColorButton(isActive: _isColorPaletteVisible),
-      textEditor, // El editor de texto crudo
+      textEditor, // Raw text editor
       widget.colorPaletteBuilder
               ?.call(context, currentColor, _onColorSelected) ??
           _buildDefaultColorPalette(currentColor),
@@ -195,7 +195,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
       widget.fontSelectorBuilder
               ?.call(context, _fontStyles, currentStyle, _onFontSelected) ??
           _buildDefaultFontSelector(currentStyle),
-      canvas, // MODIFICACIÓN CRÍTICA: El canvas ahora es una de las "piezas".
+      canvas, // CRITICAL MODIFICATION: Canvas is now one of the "pieces"
     ];
 
     return GestureDetector(
@@ -214,7 +214,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
 
   Widget _buildDefaultLayout(
       {required Color backgroundColor, required List<Widget> children}) {
-    // MODIFICACIÓN: Tomamos el canvas pre-hecho de la lista de children.
+    // MODIFICATION: Take the pre-built canvas from the children list
     final canvas = children[7];
 
     return Scaffold(
@@ -259,7 +259,7 @@ class _EscriboEditorState extends State<EscriboEditor> {
     );
   }
 
-  // ... (el resto de los métodos _build... no cambian)
+  // Rest of the _build methods remain unchanged
   Widget _buildAnimatedSwitcher(
       {required Widget child, required bool isVisible}) {
     return AnimatedSwitcher(


### PR DESCRIPTION
Introduces a new example page (EmbeddedEditorExamplePage) demonstrating the EscriboEditor embedded within a container. Enhances user experience with a toggle button to show/hide the editor and provides a gradient background for styling. Updates main.dart to include the new page in the example app.